### PR TITLE
allow_anonymous for /statistics URL requests

### DIFF
--- a/lib/bothan_deploy.rb
+++ b/lib/bothan_deploy.rb
@@ -26,8 +26,6 @@ module BothanDeploy
         allow_anonymous: lambda { |req| /statistics/.match(req.fullpath) }
 
     get '/' do
-      
-    end
       @title = 'Deploy your own Bothan'
       erb :index, layout: :default
     end

--- a/lib/bothan_deploy.rb
+++ b/lib/bothan_deploy.rb
@@ -22,9 +22,12 @@ module BothanDeploy
     use Rack::Session::Cookie, secret: ENV['BOTHAN_DEPLOY_SESSION_SECRET'], key: 'bothan_deploy_session'
     use Heroku::Bouncer,
       oauth: { id: ENV['HEROKU_OAUTH_ID'], secret: ENV['HEROKU_OAUTH_SECRET'], scope: 'write-protected' },
-      secret: ENV['HEROKU_BOUNCER_SECRET'], expose_token: true, skip: lambda { |env| env['PATH_INFO'] == '/update' }
+      secret: ENV['HEROKU_BOUNCER_SECRET'], expose_token: true, skip: lambda { |env| env['PATH_INFO'] == '/update' },
+        allow_anonymous: lambda { |req| /statistics/.match(req.fullpath) }
 
     get '/' do
+      
+    end
       @title = 'Deploy your own Bothan'
       erb :index, layout: :default
     end


### PR DESCRIPTION
This patch fixes #20

Changes proposed in this pull request:

- inclusion of a lambda which [heroku-bouncer](https://github.com/heroku/heroku-bouncer) provides to allow anonymous requests to apps using that middleware
